### PR TITLE
Updated sidecar request and limit sizes

### DIFF
--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -39,9 +39,9 @@ sidecars:
               fieldPath: metadata.namespace
       resources:
         requests:
-          cpu: "0.1"
-          memory: 128Mi
+          cpu: 10m
+          memory: 75Mi
         limits:
-          cpu: "0.2"
-          memory: 128Mi
+          cpu: 10m
+          memory: 75Mi
 


### PR DESCRIPTION
The container requests in the `sidecar.yaml` are way too high. Using Kubecost we noticed the below:

![image](https://user-images.githubusercontent.com/27896502/169895978-2c743686-54ca-44bc-9124-91d974d5fc0d.png)
 This PR reduces the size of the sidecar request to the recommended value for a prod deployment (65% usage target).